### PR TITLE
Add Tests for Unique Products Constraint

### DIFF
--- a/db/migrate/20240907131847_add_unique_index_to_products_name.rb
+++ b/db/migrate/20240907131847_add_unique_index_to_products_name.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToProductsName < ActiveRecord::Migration[7.2]
+  def change
+    add_index :products, %i[name developer_id user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 20_240_907_111_918) do
+ActiveRecord::Schema[7.2].define(version: 20_240_907_131_847) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,6 +41,8 @@ ActiveRecord::Schema[7.2].define(version: 20_240_907_111_918) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["category_id"], name: "index_products_on_category_id"
+    t.index %w[name developer_id user_id],
+            name: "index_products_on_name_and_developer_id_and_user_id", unique: true
   end
 
   add_foreign_key "products", "categories"


### PR DESCRIPTION
This update updates the schema to ensure users are not creating duplicate products in their ecommerce applications.

For developers, this means that they will be prompted when creating the same product for the the same user they previously allowed.