### PR TITLE
Improve Caching and Cache-invalidation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@
 class ApplicationController < ActionController::API
   include Authentication
   include JsonResponse
+  include Cacheable
 
   rescue_from ActiveRecord::RecordNotFound, with: :object_not_found
   rescue_from ActiveRecord::RecordNotUnique, with: :duplicate_object

--- a/app/controllers/concerns/cacheable.rb
+++ b/app/controllers/concerns/cacheable.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Implements caching for controllers
+module Cacheable
+  extend ActiveSupport::Concern
+
+  included do
+    # rubocop:disable Rails/LexicallyScopedActionFilter
+    after_action :invalidate_cache, except: %i[index show]
+    # rubocop:enable Rails/LexicallyScopedActionFilter
+  end
+
+  def base_key
+    self.class.name.underscore
+  end
+
+  # rubocop:disable Metrics/ParameterLists
+
+  # Caches a collection of resources with a generated cache key.
+  def cache_collection(
+    collection, base_key, page:, page_size:, filters: {},
+    expires_in: 2.hours
+  )
+    cache_key = generate_list_cache_key(
+      base_key:, page:, page_size:, filters:
+    )
+
+    Rails.cache.fetch(cache_key, expires_in:) do
+      yield(collection)
+    end
+  end
+
+  # rubocop:enable Metrics/ParameterLists
+
+  # Caches a single resource with a generated cache key.
+  def cache_resource(cache_key, expires_in: 2.hours, &block)
+    Rails.cache.fetch(cache_key, expires_in:, &block)
+  end
+
+  # Invalidates the cache for both the resource and related lists.
+  def invalidate_cache
+    invalidate_list_cache(base_key:) if respond_to?(:invalidate_list_cache)
+    return unless respond_to?(:invalidate_single_resource_cache)
+
+    invalidate_single_resource_cache(current_cache_key)
+  end
+
+  # Generates a cache key for paginated lists based on filters.
+  def generate_list_cache_key(base_key:, page:, page_size:, filters: {})
+    key_parts = ["#{base_key}_page_#{page}_size_#{page_size}"]
+    filters.each do |filter_key, filter_value|
+      key_parts << "#{filter_key}_#{filter_value}" if filter_value.present?
+    end
+    key_parts.join('_')
+  end
+
+  # Invalidates all caches for paginated lists matching the developer ID.
+  def invalidate_list_cache(base_key:)
+    Rails.cache.delete_matched("#{base_key}/*")
+  end
+
+  # Invalidates a specific resource's cache.
+  def invalidate_single_resource_cache(cache_key)
+    Rails.cache.delete(cache_key)
+  end
+
+  # Returns the current cache key based on the controller's context.
+  def current_cache_key
+    "#{base_key}_#{params[:id]}_#{developer_id}"
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -15,4 +15,17 @@ class Category < ApplicationRecord
 
   validates_word_count_of :description, min_words: 2, max_words: 10
   validates_word_count_of :name, min_words: 1, max_words: 10
+
+  scope :by_developer, ->(developer_id) { where(developer_id:) }
+  scope :by_name, lambda { |name|
+    where('name ILIKE ?', "%#{name}%") if name.present?
+  }
+  scope :by_search, lambda { |search|
+    if search.present?
+      where(
+        'name ILIKE :search OR description ILIKE :search',
+        search: "%#{search}%"
+      )
+    end
+  }
 end

--- a/spec/requests/api/v1/products_spec.rb
+++ b/spec/requests/api/v1/products_spec.rb
@@ -180,7 +180,9 @@ RSpec.describe "Api::V1::Products", type: :request do
       context 'with a X-Developer-Token header but not X-User-Id header' do
         before do
           allow_any_instance_of(UserServiceClient).to \
-            receive(:fetch_developer_id).and_return(developers.dig(:first, :id))
+            receive(:fetch_developer_id).and_return(
+              developers.dig(:first, :id)
+            )
         end
 
         it 'returns a 401' do
@@ -309,8 +311,9 @@ RSpec.describe "Api::V1::Products", type: :request do
           expect(response_body[:data].size).to eq(1)
           expect(response_body[:data].first.dig(:attributes, :name)).to \
             eq('Cheap Product')
-          expect(response_body[:data].first.dig(:attributes, :price).to_i).to \
-            eq(5)
+          expect(response_body[:data].first.dig(
+            :attributes, :price
+          ).to_i).to eq(5)
         end
       end
     end
@@ -330,16 +333,19 @@ RSpec.describe "Api::V1::Products", type: :request do
         allow(Product).to receive(:where).and_call_original
       end
 
-      let(:cache_key) do
-        "developer_#{developers.dig(:first, :id)}_page_1_size-100"
-      end
+      let(:base_key) { 'api/v1/products_controller' }
+      let(:page) { 1 }
+      let(:page_size) { 100 }
 
       it 'caches the product response' do
         get api_v1_products_url, headers: valid_headers[:first_dev]
 
         expect(response).to have_http_status(:ok)
         expect(Rails.cache).to have_received(:fetch)
-          .with(cache_key, expires_in: 2.hours)
+          .with(
+            "#{base_key}_page_#{page}_size_#{page_size}",
+            expires_in: 2.hours
+          )
       end
 
       it 'caches the product response with filters' do
@@ -348,7 +354,10 @@ RSpec.describe "Api::V1::Products", type: :request do
 
         expect(response).to have_http_status(:ok)
         expect(Rails.cache).to have_received(:fetch)
-          .with("#{cache_key}_name-Microwave", expires_in: 2.hours)
+          .with(
+            "#{base_key}_page_#{page}_size_#{page_size}_name_Microwave",
+            expires_in: 2.hours
+          )
       end
     end
   end


### PR DESCRIPTION
This update improves the caching for products and categories by ensuring that items are fetched once from the database.
Subsequent calls asking for the same resource or data will be returned from the cached version.

To ensure that results are not stale, cached data are invalidated when an update or deletion occurs. This helps to ensure that users receive the latest resource or resources anytime they make a request.

The current test cases still pass after a few minor tweaks as a result of the new change.